### PR TITLE
Run RoonServer as a non-privileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,16 @@ MAINTAINER steef@debruijn.ws
 
 RUN apt-get update \
         && apt-get -y upgrade \
-        && apt-get -y install bash curl bzip2 ffmpeg cifs-utils alsa-utils
+        && apt-get -y install bash curl bzip2 ffmpeg cifs-utils alsa-utils gnupg \
+        && adduser --system --group --shell /bin/false --no-create-home --disabled-password roonserver
+
+# Install gosu for privilege dropping
+RUN gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.11/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.11/gosu-$(dpkg --print-architecture).asc" \
+    && gpg --verify /usr/local/bin/gosu.asc \
+    && rm /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu
 
 ENV ROON_SERVER_PKG RoonServer_linuxx64.tar.bz2
 ENV ROON_SERVER_URL http://download.roonlabs.com/builds/${ROON_SERVER_PKG}
@@ -13,5 +22,6 @@ ENV ROON_ID_DIR /data
 VOLUME [ "/app", "/data", "/music", "/backup" ]
 
 ADD run.sh /
-ENTRYPOINT /run.sh
+ADD entrypoint.sh /
 
+ENTRYPOINT /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,8 @@ MAINTAINER steef@debruijn.ws
 
 RUN apt-get update \
         && apt-get -y upgrade \
-        && apt-get -y install bash curl bzip2 ffmpeg cifs-utils alsa-utils gnupg \
+        && apt-get -y install bash curl bzip2 ffmpeg cifs-utils alsa-utils gosu \
         && adduser --system --group --shell /bin/false --no-create-home --disabled-password roonserver
-
-# Install gosu for privilege dropping
-RUN gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.11/gosu-$(dpkg --print-architecture)" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.11/gosu-$(dpkg --print-architecture).asc" \
-    && gpg --verify /usr/local/bin/gosu.asc \
-    && rm /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu
 
 ENV ROON_SERVER_PKG RoonServer_linuxx64.tar.bz2
 ENV ROON_SERVER_URL http://download.roonlabs.com/builds/${ROON_SERVER_PKG}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+chown roonserver:roonserver /app /data /backup
+exec /usr/local/bin/gosu roonserver /run.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 chown roonserver:roonserver /app /data /backup
-exec /usr/local/bin/gosu roonserver /run.sh
+exec /usr/sbin/gosu roonserver /run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 cd /app
 if test ! -d RoonServer; then
-        curl $ROON_SERVER_URL -O
-        tar xjf $ROON_SERVER_PKG
-        rm -f $ROON_SERVER_PKG
+        curl "$ROON_SERVER_URL" -O
+        tar xjf "$ROON_SERVER_PKG"
+        rm -f "$ROON_SERVER_PKG"
 fi
 /app/RoonServer/start.sh


### PR DESCRIPTION
To prevent accidental priviledge escalation on the host, this change uses https://github.com/tianon/gosu to drop root privileges at startup time, after changing directory ownership to allow the new `roonserver` user to write to `data`, `backup` and `app` directories.